### PR TITLE
Replace `request.content_type` with `request.media_type` for compatibility with the default behavior of Rails 7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+- Replace `request.content_type` with `request.media_type` for compatibility with the default behavior of Rails 7.0
+
 ## 0.9.0
 
 - mod(brake): adjust to OAS3 spec

--- a/lib/swagger/serializer/rails_controller.rb
+++ b/lib/swagger/serializer/rails_controller.rb
@@ -46,8 +46,8 @@ module Swagger::Serializer::RailsController
 
   def body_deserializer
     @body_deserializer ||=
-      if request.content_type
-        swagger_operation.request_body.content[request.content_type]&.deserializer
+      if request.media_type
+        swagger_operation.request_body.content[request.media_type]&.deserializer
       end
   end
 


### PR DESCRIPTION
To fix https://github.com/Narazaka/swagger-serializer/issues/5.